### PR TITLE
ローディング中、エラー時のアラート表示対応、全体レイアウトにGrid適用

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,10 +1,12 @@
-import { VFC } from 'react';
+import { VFC, ComponentPropsWithRef } from 'react';
 import Image from 'next/image';
 import { css } from '@emotion/react';
 
-const Footer: VFC = () => {
+type Props = ComponentPropsWithRef<'footer'>;
+
+const Footer: VFC<Props> = ({ ...props }) => {
   return (
-    <footer css={[footer, footerText]}>
+    <footer css={[footer, footerText]} {...props}>
       <span>
         created by <span css={name}>h-yoshikawa44</span> - devChallenges.io
         |&nbsp;

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -15,6 +15,11 @@ const Header: VFC<Props> = ({ onRandom, ...props }) => {
 };
 
 const header = css`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  min-height: 64px;
+  padding: 0 4%;
   text-align: right;
 `;
 

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -10,28 +10,33 @@ type Props = {
 };
 
 const Layout: FC<Props> = ({ pageName, onRandom, children }) => {
+  const title = pageName
+    ? `${pageName} - Random quote generator`
+    : 'Random quote generator';
   const content = pageName
     ? `devChallenges.io - Random quote generator - ${pageName} | by h-yoshikawa44`
     : 'devChallenges.io - Random quote generator | by h-yoshikawa44';
   return (
-    <div>
+    <div css={globalLayout}>
       <Head>
-        <title>Random quote generator</title>
+        <title>{title}</title>
         <meta name="description" content={content} />
       </Head>
-      <div css={headerContainer}>
-        <Header onRandom={onRandom} />
-      </div>
-      <div css={container}>{children}</div>
-      <Footer />
+      <Header css={customHeader} onRandom={onRandom} />
+      <div css={[container, contents]}>{children}</div>
+      <Footer css={customFooter} />
     </div>
   );
 };
 
-const headerContainer = css`
-  max-width: 1280px;
-  padding: 0 4%;
-  margin: 24px auto 0;
+const globalLayout = css`
+  display: grid;
+  grid-template: 'header' auto 'contents' 1fr 'footer' auto/100%;
+  min-height: 100vh;
+`;
+
+const customHeader = css`
+  grid-area: header;
 `;
 
 const container = css`
@@ -42,6 +47,14 @@ const container = css`
   @media (max-width: 600px) {
     padding: 0 8%;
   }
+`;
+
+const contents = css`
+  grid-area: contents;
+`;
+
+const customFooter = css`
+  grid-area: footer;
 `;
 
 export default Layout;

--- a/src/components/QuoteBlock/index.tsx
+++ b/src/components/QuoteBlock/index.tsx
@@ -1,9 +1,22 @@
 import { FC, ComponentPropsWithRef } from 'react';
 import { css } from '@emotion/react';
+import Skeleton from '@/components/common/Skeleton';
 
-type Props = ComponentPropsWithRef<'blockquote'>;
+type Props = ComponentPropsWithRef<'blockquote'> & {
+  isLoading?: boolean;
+};
 
-const QuoteBlock: FC<Props> = ({ children, ...props }) => {
+const QuoteBlock: FC<Props> = ({ isLoading = false, children, ...props }) => {
+  if (isLoading) {
+    return (
+      <blockquote css={[quoteBlock, quoteSkeletonBox]} {...props}>
+        <Skeleton css={quoteSkeleton} width="100%" />
+        <Skeleton css={quoteSkeleton} width="100%" />
+        <Skeleton css={quoteSkeleton} width="100%" />
+      </blockquote>
+    );
+  }
+
   return (
     <blockquote css={quoteBlock} {...props}>
       <p css={quoteText}>{`“${children}”`}</p>
@@ -12,13 +25,34 @@ const QuoteBlock: FC<Props> = ({ children, ...props }) => {
 };
 
 const quoteBlock = css`
-  position: relative;
   padding-left: 96px;
   border-left: 8px solid #f7df94;
 
   @media (max-width: 600px) {
     padding-left: 40px;
     border-width: 4px;
+  }
+`;
+
+const quoteSkeletonBox = css`
+  display: grid;
+  grid-row-gap: 16px;
+
+  @media (max-width: 600px) {
+    grid-row-gap: 8px;
+  }
+`;
+
+const quoteSkeleton = css`
+  max-width: 616px;
+  height: 36px;
+
+  @media (max-width: 1280px) {
+    height: 32px;
+  }
+
+  @media (max-width: 600px) {
+    height: 20px;
   }
 `;
 

--- a/src/components/common/Alert/index.tsx
+++ b/src/components/common/Alert/index.tsx
@@ -1,0 +1,38 @@
+import { VFC, ComponentPropsWithRef } from 'react';
+import { css } from '@emotion/react';
+import { ErrorOutline } from '@emotion-icons/material-rounded/ErrorOutline';
+
+type Props = ComponentPropsWithRef<'div'>;
+
+const Alert: VFC<Props> = ({ ...props }) => {
+  return (
+    <div css={alert} role="alert" {...props}>
+      <ErrorOutline css={alertIcon} size={24} />
+      <p css={alertText}>
+        Failed to obtain quote data. Please try again in a few minutes.
+      </p>
+    </div>
+  );
+};
+
+const alert = css`
+  display: inline-flex;
+  align-items: center;
+  padding: 16px;
+  background-color: #fdecea;
+  border-radius: 8px;
+`;
+
+const alertIcon = css`
+  color: #f44336;
+`;
+
+const alertText = css`
+  margin-left: 16px;
+  font-family: Raleway, sans-serif;
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 120%;
+`;
+
+export default Alert;

--- a/src/components/common/Skeleton/index.tsx
+++ b/src/components/common/Skeleton/index.tsx
@@ -1,0 +1,66 @@
+import { VFC, ComponentPropsWithRef } from 'react';
+import { jsx, css, keyframes } from '@emotion/react';
+
+type Props = (
+  | (ComponentPropsWithRef<'div'> & {
+      component?: 'div';
+    })
+  | (ComponentPropsWithRef<'span'> & {
+      component: 'span';
+    })
+) & {
+  width?: number | string;
+  height?: number | string;
+};
+
+const Skeleton: VFC<Props> = ({
+  component = 'div',
+  width = 'auto',
+  height = 'auto',
+  ...props
+}) => {
+  return jsx(component, {
+    css: skeleton(width, height),
+    ...props,
+  });
+};
+
+const skeleton = (width: number | string, height: number | string) => {
+  const convertWidth = typeof width === 'number' ? `${width}px` : width;
+  const convertHeight = typeof height === 'number' ? `${height}px` : height;
+  return css`
+    position: relative;
+    width: ${convertWidth};
+    height: ${convertHeight};
+    overflow: hidden;
+    background: #d9d9d9;
+
+    &::before {
+      position: absolute;
+      top: 0;
+      left: 0;
+      display: block;
+      width: 100%;
+      height: 100%;
+      content: '';
+      background: linear-gradient(
+        90deg,
+        transparent,
+        rgba(255, 255, 255, 0.5),
+        transparent
+      );
+      animation: ${skeletonAnimation} 1.2s linear infinite;
+    }
+  `;
+};
+
+const skeletonAnimation = keyframes`
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+`;
+
+export default Skeleton;

--- a/src/pages/[author].tsx
+++ b/src/pages/[author].tsx
@@ -1,16 +1,93 @@
-import { Fragment, useCallback } from 'react';
+import { VFC, Fragment, useCallback } from 'react';
 import { useRouter } from 'next/router';
 import { css } from '@emotion/react';
 import Layout from '@/components/Layout';
 import QuoteBlock from '@/components/QuoteBlock';
-import { useGetQuoteListInfiniteQuey } from '@/hooks/quote';
+import { useGetQuoteListInfiniteQuey } from '@/hooks//quote';
 import { useIntersectionObserver } from '@/hooks/util';
+import { QuoteData } from '@/models/Quote';
+
+type Props = {
+  isLoading: boolean;
+  quoteData: QuoteData[];
+  loadMoreRef: (node: Element) => void;
+  loadMoreMessage: string;
+};
+
+const QuoteBlockList: VFC<Props> = ({
+  isLoading,
+  quoteData,
+  loadMoreRef,
+  loadMoreMessage,
+}) => {
+  if (isLoading) {
+    return (
+      <div css={quoteBlockList}>
+        <QuoteBlock isLoading={isLoading} />
+        <QuoteBlock isLoading={isLoading} />
+        <QuoteBlock isLoading={isLoading} />
+      </div>
+    );
+  }
+
+  return (
+    <div css={quoteBlockList}>
+      {quoteData?.map((page) => (
+        <Fragment key={page.pagination.currentPage}>
+          {page.data.map((quote) => (
+            <QuoteBlock key={quote._id}>{quote.quoteText}</QuoteBlock>
+          ))}
+        </Fragment>
+      ))}
+      <div css={loadMoreBox} ref={loadMoreRef}>
+        {loadMoreMessage}
+      </div>
+    </div>
+  );
+};
+
+const quoteBlockList = css`
+  display: grid;
+  grid-template-columns: 616px;
+  grid-row-gap: 136px;
+
+  @media (max-width: 1280px) {
+    grid-row-gap: 96px;
+  }
+
+  @media (max-width: 600px) {
+    grid-template-columns: 1fr;
+    grid-row-gap: 64px;
+  }
+`;
+
+const authorNameText = css`
+  margin-left: 104px;
+  font-family: Raleway, sans-serif;
+  font-size: 36px;
+  font-weight: bold;
+  line-height: 42px;
+
+  @media (max-width: 600px) {
+    margin-left: 44px;
+    font-size: 32px;
+  }
+`;
+
+const loadMoreBox = css`
+  font-family: Raleway, sans-serif;
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 120%;
+  text-align: center;
+`;
 
 const AuthorQuotes = () => {
   const router = useRouter();
   const authorName = (router.query.author as string)?.replace('_', ' ');
 
   const {
+    isLoading,
     data: quoteList,
     hasNextPage,
     isFetchingNextPage,
@@ -45,16 +122,12 @@ const AuthorQuotes = () => {
     <Layout onRandom={handleBackTopPage}>
       <main css={main}>
         <h2 css={authorNameText}>{authorName}</h2>
-        {quoteList?.pages?.map((page) => (
-          <Fragment key={page.pagination.currentPage}>
-            {page.data.map((quote) => (
-              <QuoteBlock key={quote._id}>{quote.quoteText}</QuoteBlock>
-            ))}
-          </Fragment>
-        ))}
-        <div css={loadMoreBox} ref={loadMoreRef}>
-          {loadMoreMessage}
-        </div>
+        <QuoteBlockList
+          isLoading={isLoading}
+          quoteData={quoteList?.pages}
+          loadMoreRef={loadMoreRef}
+          loadMoreMessage={loadMoreMessage}
+        />
       </main>
     </Layout>
   );
@@ -75,27 +148,6 @@ const main = css`
     grid-row-gap: 64px;
     padding: 80px 0;
   }
-`;
-
-const authorNameText = css`
-  margin-left: 104px;
-  font-family: Raleway, sans-serif;
-  font-size: 36px;
-  font-weight: bold;
-  line-height: 42px;
-
-  @media (max-width: 600px) {
-    margin-left: 44px;
-    font-size: 32px;
-  }
-`;
-
-const loadMoreBox = css`
-  font-family: Raleway, sans-serif;
-  font-size: 18px;
-  font-weight: 500;
-  line-height: 120%;
-  text-align: center;
 `;
 
 export default AuthorQuotes;

--- a/src/pages/[author].tsx
+++ b/src/pages/[author].tsx
@@ -3,12 +3,14 @@ import { useRouter } from 'next/router';
 import { css } from '@emotion/react';
 import Layout from '@/components/Layout';
 import QuoteBlock from '@/components/QuoteBlock';
+import Alert from '@/components/common/Alert';
 import { useGetQuoteListInfiniteQuey } from '@/hooks//quote';
 import { useIntersectionObserver } from '@/hooks/util';
 import { QuoteData } from '@/models/Quote';
 
 type Props = {
   isLoading: boolean;
+  statusCode?: number;
   quoteData: QuoteData[];
   loadMoreRef: (node: Element) => void;
   loadMoreMessage: string;
@@ -16,6 +18,7 @@ type Props = {
 
 const QuoteBlockList: VFC<Props> = ({
   isLoading,
+  statusCode,
   quoteData,
   loadMoreRef,
   loadMoreMessage,
@@ -26,6 +29,14 @@ const QuoteBlockList: VFC<Props> = ({
         <QuoteBlock isLoading={isLoading} />
         <QuoteBlock isLoading={isLoading} />
         <QuoteBlock isLoading={isLoading} />
+      </div>
+    );
+  }
+
+  if (statusCode) {
+    return (
+      <div css={quoteBlockList}>
+        <Alert />
       </div>
     );
   }
@@ -88,6 +99,7 @@ const AuthorQuotes = () => {
 
   const {
     isLoading,
+    error,
     data: quoteList,
     hasNextPage,
     isFetchingNextPage,
@@ -101,6 +113,7 @@ const AuthorQuotes = () => {
     },
     { enabled: !!authorName }
   );
+  const statusCode = error?.response?.status;
 
   const { loadMoreRef } = useIntersectionObserver({
     onIntersect: fetchNextPage,
@@ -124,6 +137,7 @@ const AuthorQuotes = () => {
         <h2 css={authorNameText}>{authorName}</h2>
         <QuoteBlockList
           isLoading={isLoading}
+          statusCode={statusCode}
           quoteData={quoteList?.pages}
           loadMoreRef={loadMoreRef}
           loadMoreMessage={loadMoreMessage}

--- a/src/pages/[author].tsx
+++ b/src/pages/[author].tsx
@@ -132,7 +132,7 @@ const AuthorQuotes = () => {
   }, [router]);
 
   return (
-    <Layout onRandom={handleBackTopPage}>
+    <Layout pageName={authorName} onRandom={handleBackTopPage}>
       <main css={main}>
         <h2 css={authorNameText}>{authorName}</h2>
         <QuoteBlockList

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,13 +6,18 @@ import { dehydrate } from 'react-query/hydration';
 import Layout from '@/components/Layout';
 import QuoteBlock from '@/components/QuoteBlock';
 import AuthorLinkCard from '@/components/AuthorLinkCard';
+import Alert from '@/components/common/Alert';
 import {
   randomQuotePrefetchQuery,
   useGetRandomQuoteQuery,
 } from '@/hooks/quote';
 
 const Home = () => {
-  const { data: quoteData, refetch } = useGetRandomQuoteQuery(
+  const {
+    error,
+    data: quoteData,
+    refetch,
+  } = useGetRandomQuoteQuery(
     {},
     {
       enabled: false,
@@ -22,6 +27,17 @@ const Home = () => {
   const handleRandomQuote = useCallback(() => {
     refetch();
   }, [refetch]);
+  const statusCode = error?.response?.status;
+
+  if (statusCode) {
+    return (
+      <Layout onRandom={handleRandomQuote}>
+        <main css={main}>
+          <Alert />
+        </main>
+      </Layout>
+    );
+  }
 
   return (
     <Layout onRandom={handleRandomQuote}>


### PR DESCRIPTION
## Issue番号
closes #7 

## 対応内容
- ランダム引用データ取得ページ
  - エラー表示
- 特定の引用者の引用データ取得ページ
  - ローディング中はスケルトンなりを表示する
  - エラー表示
- 全体
  - レイアウトに Grid を適用し、コンテンツが少なくてもフッターが上がってこないように
  - 細かなスタイル調整 